### PR TITLE
Remove --no-restore from dotnet publish in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN dotnet restore CareGuide.API/CareGuide.API.csproj
 COPY . .
 WORKDIR /src/CareGuide.API
 
-RUN dotnet publish -c Release -o /app/publish --no-restore
+RUN dotnet publish -c Release -o /app/publish
 
 FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS runtime
 WORKDIR /app


### PR DESCRIPTION
- Fixed Docker build error by removing the --no-restore flag from the dotnet publish command
- Ensures all NuGet packages are restored during publish step for reliable container builds