### PR TITLE
Standardize ErrorHandlerMiddleware to RFC 9457 Problem Details

### DIFF
--- a/CareGuide.API/Middlewares/ErrorHandlerMiddleware.cs
+++ b/CareGuide.API/Middlewares/ErrorHandlerMiddleware.cs
@@ -1,12 +1,23 @@
-﻿using CareGuide.Models.Exceptions;
+﻿using System.Net;
+using CareGuide.Models.Exceptions;
 using FluentValidation;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
-
 
 namespace CareGuide.API.Middlewares
 {
     public class ErrorHandlerMiddleware : IMiddleware
     {
+        private static string PT(string slug) => "about:blank";
+        private readonly ILogger<ErrorHandlerMiddleware> _logger;
+        private readonly IWebHostEnvironment _env;
+
+        public ErrorHandlerMiddleware(ILogger<ErrorHandlerMiddleware> logger, IWebHostEnvironment env)
+        {
+            _logger = logger;
+            _env = env;
+        }
+
         public async Task InvokeAsync(HttpContext context, RequestDelegate next)
         {
             try
@@ -15,58 +26,217 @@ namespace CareGuide.API.Middlewares
                 request.EnableBuffering();
                 await next(context);
             }
-            catch (UnauthorizedAccessException ex)
+            catch (ValidationException vex)
             {
-                await HandleExceptionAsync(context, ex.Message, 401);
+                _logger.LogWarning(vex, "Validation error");
+                await HandleValidationExceptionAsync(context, vex);
             }
-            catch (InvalidOperationException ex)
+            catch (DbUpdateConcurrencyException cex)
             {
-                await HandleExceptionAsync(context, ex.Message, 400);
+                _logger.LogWarning(cex, "EF Core concurrency conflict");
+                await HandleEfConcurrencyExceptionAsync(context, cex);
             }
-            catch (DbUpdateException ex)
+            catch (DbUpdateException dbex)
             {
-                await HandleExceptionAsync(context, ex.InnerException?.Message ?? ex.Message, 400);
+                _logger.LogWarning(dbex, "EF Core update exception");
+                await HandleEfUpdateExceptionAsync(context, dbex);
             }
-            catch (NotFoundException ex)
+            catch (TimeoutException tex)
             {
-                await HandleExceptionAsync(context, ex.InnerException?.Message ?? ex.Message, 404);
+                _logger.LogError(tex, "Operation timeout");
+                await HandleTimeoutExceptionAsync(context, tex);
             }
-            catch (KeyNotFoundException ex)
+            catch (NotFoundException nfex)
             {
-                await HandleExceptionAsync(context, ex.InnerException?.Message ?? ex.Message, 404);
+                _logger.LogWarning(nfex, "Resource not found");
+                await HandleNotFoundExceptionAsync(context, nfex);
             }
-            catch (ValidationException ex)
+            catch (KeyNotFoundException kex)
             {
-                var errors = ex.Errors.Select(error => new
-                {
-                    Field = error.PropertyName,
-                    Error = error.ErrorMessage
-                });
-
-                await HandleValidationExceptionAsync(context, errors, 400);
+                _logger.LogWarning(kex, "Key not found");
+                await HandleNotFoundExceptionAsync(context, kex);
             }
             catch (Exception ex)
             {
-                await HandleExceptionAsync(context, ex.Message, 500);
+                await HandleExceptionAsync(context, ex);
             }
         }
 
-        private async Task HandleExceptionAsync(HttpContext context, string message, int statusCode = 500)
+        private ProblemDetails CreateProblemDetails(HttpContext context, int statusCode, string title, string? detail = null, string? type = null, IDictionary<string, object>? extensions = null)
         {
-            context.Response.ContentType = "application/text";
-            context.Response.StatusCode = statusCode;
-            await context.Response.WriteAsync(message);
+            var problem = new ProblemDetails
+            {
+                Type = type ?? "about:blank",
+                Title = title,
+                Status = statusCode,
+                Detail = detail,
+                Instance = context.Request.Path + context.Request.QueryString
+            };
+
+            if (_env.IsDevelopment())
+            {
+                problem.Extensions["traceId"] = context.TraceIdentifier;
+            }
+
+            if (extensions is not null)
+            {
+                foreach (var kvp in extensions)
+                    problem.Extensions[kvp.Key] = kvp.Value;
+            }
+
+            return problem;
         }
 
-        private async Task HandleValidationExceptionAsync(HttpContext context, object errors, int statusCode = 400)
+        private Task HandleValidationExceptionAsync(HttpContext context, ValidationException vex)
         {
-            context.Response.ContentType = "application/json";
-            context.Response.StatusCode = statusCode;
-            await context.Response.WriteAsJsonAsync(new
+            context.Response.ContentType = "application/problem+json";
+            context.Response.StatusCode = (int)HttpStatusCode.BadRequest;
+
+            var errors = vex.Errors
+                .GroupBy(e => e.PropertyName)
+                .ToDictionary(g => g.Key, g => g.Select(e => e.ErrorMessage).ToArray());
+
+            var problem = CreateProblemDetails(
+                context,
+                context.Response.StatusCode,
+                title: "Validation failed.",
+                detail: "One or more fields are invalid.",
+                type: PT("validation-error"),
+                extensions: new Dictionary<string, object> { ["errors"] = errors }
+            );
+
+            return context.Response.WriteAsJsonAsync(problem);
+        }
+
+        private Task HandleEfConcurrencyExceptionAsync(HttpContext context, DbUpdateConcurrencyException ex)
+        {
+            context.Response.ContentType = "application/problem+json";
+            context.Response.StatusCode = (int)HttpStatusCode.Conflict;
+
+            var extensions = _env.IsDevelopment()
+                ? new Dictionary<string, object>
+                {
+                    ["entries"] = ex.Entries.Select(e => e.Entity.GetType().Name).ToArray(),
+                    ["stackTrace"] = ex.StackTrace ?? string.Empty
+                }
+                : null;
+
+            var problem = CreateProblemDetails(
+                context,
+                context.Response.StatusCode,
+                title: "Concurrency conflict.",
+                detail: "The resource was modified by another operation. Refresh and try again.",
+                type: PT("concurrency-conflict"),
+                extensions: extensions
+            );
+
+            return context.Response.WriteAsJsonAsync(problem);
+        }
+
+        private Task HandleEfUpdateExceptionAsync(HttpContext context, DbUpdateException ex)
+        {
+            context.Response.ContentType = "application/problem+json";
+            context.Response.StatusCode = (int)HttpStatusCode.BadRequest;
+
+            var extensions = _env.IsDevelopment()
+                ? new Dictionary<string, object> { ["stackTrace"] = ex.StackTrace ?? string.Empty }
+                : null;
+
+            var problem = CreateProblemDetails(
+                context,
+                context.Response.StatusCode,
+                title: "Failed to persist changes.",
+                detail: ex.Message,
+                type: PT("persistence-failure"),
+                extensions: extensions
+            );
+
+            return context.Response.WriteAsJsonAsync(problem);
+        }
+
+        private Task HandleTimeoutExceptionAsync(HttpContext context, TimeoutException ex)
+        {
+            context.Response.ContentType = "application/problem+json";
+            context.Response.StatusCode = 504;
+
+            var extensions = _env.IsDevelopment()
+                ? new Dictionary<string, object> { ["stackTrace"] = ex.StackTrace ?? string.Empty }
+                : null;
+
+            var problem = CreateProblemDetails(
+                context,
+                504,
+                title: "Execution timeout exceeded.",
+                detail: "The operation took longer than expected. Please try again.",
+                type: PT("operation-timeout"),
+                extensions: extensions
+            );
+
+            return context.Response.WriteAsJsonAsync(problem);
+        }
+
+        private Task HandleNotFoundExceptionAsync(HttpContext context, Exception ex)
+        {
+            context.Response.ContentType = "application/problem+json";
+            context.Response.StatusCode = (int)HttpStatusCode.NotFound;
+
+            var extensions = _env.IsDevelopment()
+                ? new Dictionary<string, object> { ["stackTrace"] = ex.StackTrace ?? string.Empty }
+                : null;
+
+            var problem = CreateProblemDetails(
+                context,
+                context.Response.StatusCode,
+                title: "Resource not found.",
+                detail: ex.Message,
+                type: PT("not-found"),
+                extensions: extensions
+            );
+
+            return context.Response.WriteAsJsonAsync(problem);
+        }
+
+        private Task HandleExceptionAsync(HttpContext context, Exception exception)
+        {
+            var statusCode = exception switch
             {
-                Message = "Validation failed",
-                Errors = errors
-            });
+                ArgumentNullException => (int)HttpStatusCode.BadRequest,
+                ArgumentException => (int)HttpStatusCode.BadRequest,
+                KeyNotFoundException => (int)HttpStatusCode.NotFound,
+                UnauthorizedAccessException => (int)HttpStatusCode.Unauthorized,
+                HttpRequestException => (int)HttpStatusCode.BadRequest,
+                InvalidOperationException => (int)HttpStatusCode.BadRequest,
+                NotImplementedException => (int)HttpStatusCode.NotImplemented,
+                _ => (int)HttpStatusCode.InternalServerError
+            };
+
+            context.Response.ContentType = "application/problem+json";
+            context.Response.StatusCode = statusCode;
+
+            LogException(exception, statusCode);
+
+            var extensions = _env.IsDevelopment()
+                ? new Dictionary<string, object> { ["stackTrace"] = exception.StackTrace ?? string.Empty }
+                : null;
+
+            var problem = CreateProblemDetails(
+                context,
+                statusCode,
+                title: "An unexpected error occurred.",
+                detail: exception.Message,
+                type: null,
+                extensions: extensions
+            );
+
+            return context.Response.WriteAsJsonAsync(problem);
+        }
+
+        private void LogException(Exception ex, int statusCode)
+        {
+            if (statusCode >= 500)
+                _logger.LogError(ex, "Internal server error: {Message}", ex.Message);
+            else
+                _logger.LogWarning(ex, "Request error: {Message}", ex.Message);
         }
     }
 }


### PR DESCRIPTION
- Refactored ErrorHandlerMiddleware to return error responses using RFC 9457 Problem Details format
- Ensured all error types use about:blank when no specific documentation URL is available
- Improved consistency and interoperability of API error handling
- Reference: [RFC 9457 - Problem Details for HTTP APIs](https://www.rfc-editor.org/rfc/rfc9457.html)