### PR TITLE
Chore: Add centralized API versioning prefix using constant

### DIFF
--- a/CareGuide.API/Controllers/AccountController.cs
+++ b/CareGuide.API/Controllers/AccountController.cs
@@ -6,7 +6,7 @@ using Microsoft.AspNetCore.Mvc;
 namespace CareGuide.API.Controllers
 {
     [ApiController]
-    [Route("[controller]")]
+    [Route(CareGuide.Models.Constants.ApiConstants.VersionPrefix + "/[controller]")]
     public class AccountController : ControllerBase
     {
         private readonly IAccountService _accountService;

--- a/CareGuide.API/Controllers/HealthCheckController.cs
+++ b/CareGuide.API/Controllers/HealthCheckController.cs
@@ -5,7 +5,7 @@ using Microsoft.AspNetCore.Mvc;
 namespace CareGuide.API.Controllers
 {
     [ApiController]
-    [Route("[controller]")]
+    [Route(CareGuide.Models.Constants.ApiConstants.VersionPrefix + "/[controller]")]
     public class HealthCheckController : ControllerBase
     {
         private readonly IUserSessionContext _userSessionContext;

--- a/CareGuide.API/Controllers/PersonAnnotationController.cs
+++ b/CareGuide.API/Controllers/PersonAnnotationController.cs
@@ -5,7 +5,7 @@ using Microsoft.AspNetCore.Mvc;
 namespace CareGuide.API.Controllers
 {
     [ApiController]
-    [Route("[controller]")]
+    [Route(CareGuide.Models.Constants.ApiConstants.VersionPrefix + "/[controller]")]
     public class PersonAnnotationController : ControllerBase
     {
         private readonly IPersonAnnotationService _personAnnotationService;

--- a/CareGuide.Models/Constants/ApiConstants.cs
+++ b/CareGuide.Models/Constants/ApiConstants.cs
@@ -1,0 +1,7 @@
+namespace CareGuide.Models.Constants
+{
+  public static class ApiConstants
+  {
+    public const string VersionPrefix = "api/v1";
+  }
+}


### PR DESCRIPTION
- Introduced `ApiConstants.VersionPrefix` for centralized API versioning
- Updated all controller routes to use the version prefix constant
- Simplified future version updates and improved maintainability of API route structure