### PR TITLE
Chore: remove FluentValidation.AspNetCore and update Scalar.AspNetCore to 2.8.1

### DIFF
--- a/CareGuide.API/CareGuide.API.csproj
+++ b/CareGuide.API/CareGuide.API.csproj
@@ -13,7 +13,6 @@
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="15.0.1" />
     <PackageReference Include="FluentValidation" Version="12.0.0" />
-    <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.1" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.9" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.9" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.9">
@@ -25,7 +24,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
-    <PackageReference Include="Scalar.AspNetCore" Version="2.8.0" />
+    <PackageReference Include="Scalar.AspNetCore" Version="2.8.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.4" />
 
   </ItemGroup>

--- a/CareGuide.Infra/CommomStartupMethods.cs
+++ b/CareGuide.Infra/CommomStartupMethods.cs
@@ -1,11 +1,11 @@
 ﻿using CareGuide.Data;
 using CareGuide.Data.TransactionManagement;
 using CareGuide.Infra.CrossCutting;
+using CareGuide.Models.DTOs.Auth;
 using CareGuide.Models.Validators;
 using CareGuide.Security;
 using CareGuide.Security.Interfaces;
 using FluentValidation;
-using FluentValidation.AspNetCore;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -59,8 +59,8 @@ namespace CareGuide.Infra
 
         private static void ConfigureValidators(IServiceCollection services)
         {
-            services.AddFluentValidationAutoValidation().AddFluentValidationClientsideAdapters();
-            services.AddValidatorsFromAssemblyContaining<CreateAccountDtoValidator>();
+            services.AddTransient<IValidator<CreateAccountDto>, CreateAccountDtoValidator>();
+            services.AddTransient<IValidator<UpdatePasswordAccountDto>, UpdatePasswordAccountDtoValidator>();
         }
     }
 }

--- a/CareGuide.Models/CareGuide.Models.csproj
+++ b/CareGuide.Models/CareGuide.Models.csproj
@@ -17,7 +17,6 @@
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="15.0.1" />
     <PackageReference Include="FluentValidation" Version="12.0.0" />
-    <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
- Remove `FluentValidation.AspNetCore` package from project files
- Update `Scalar.AspNetCore` dependency from version 2.8.0 to 2.8.1
- Adjust validator configuration to use only `FluentValidation`
- Ensure compatibility with latest dependency versions