### PR TITLE
Refactor: Refactor PersonAnnotation endpoints to use logged-in user's personId, update UserSessionContext and JWT, and improve mappers

### DIFF
--- a/CareGuide.API/Controllers/HealthCheckController.cs
+++ b/CareGuide.API/Controllers/HealthCheckController.cs
@@ -1,5 +1,4 @@
-﻿using CareGuide.API.Attributes;
-using CareGuide.Security.Interfaces;
+﻿using CareGuide.Security.Interfaces;
 using Microsoft.AspNetCore.Mvc;
 
 namespace CareGuide.API.Controllers
@@ -16,13 +15,6 @@ namespace CareGuide.API.Controllers
         }
 
         [HttpGet]
-        [IgnoreSessionMiddleware]
-        public IResult HealthStatus()
-        {
-            return Results.NoContent();
-        }
-
-        [HttpGet("private")]
         public IResult HealthPrivateStatus()
         {
             return Results.Ok(_userSessionContext.UserId);

--- a/CareGuide.API/Controllers/PersonAnnotationController.cs
+++ b/CareGuide.API/Controllers/PersonAnnotationController.cs
@@ -16,10 +16,10 @@ namespace CareGuide.API.Controllers
             _personAnnotationService = personAnnotationService;
         }
 
-        [HttpGet("person/{personId}")]
-        public async Task<IResult> GetAllByPerson([FromRoute] Guid personId, [FromQuery] int page = PaginationConstants.DefaultPage, [FromQuery] int pageSize = PaginationConstants.DefaultPageSize, CancellationToken cancellationToken = default)
+        [HttpGet]
+        public async Task<IResult> GetAllByPerson([FromQuery] int page = PaginationConstants.DefaultPage, [FromQuery] int pageSize = PaginationConstants.DefaultPageSize, CancellationToken cancellationToken = default)
         {
-            var result = await _personAnnotationService.GetAllByPersonAsync(personId, page, pageSize, cancellationToken);
+            var result = await _personAnnotationService.GetAllByPersonAsync(page, pageSize, cancellationToken);
             return Results.Ok(result);
         }
 
@@ -42,10 +42,10 @@ namespace CareGuide.API.Controllers
             return Results.Ok(await _personAnnotationService.UpdateAsync(id, updatePersonAnnotation, cancellationToken));
         }
 
-        [HttpDelete("person/{personId}")]
-        public async Task<IResult> DeleteAllByPerson([FromRoute] Guid personId, CancellationToken cancellationToken)
+        [HttpDelete("person")]
+        public async Task<IResult> DeleteAllByPerson(CancellationToken cancellationToken)
         {
-            await _personAnnotationService.DeleteAllByPersonAsync(personId, cancellationToken);
+            await _personAnnotationService.DeleteAllByPersonAsync(cancellationToken);
             return Results.NoContent();
         }
 

--- a/CareGuide.API/Program.cs
+++ b/CareGuide.API/Program.cs
@@ -1,4 +1,3 @@
-
 using CareGuide.API.Middlewares;
 using CareGuide.Data;
 using CareGuide.Infra;
@@ -67,6 +66,9 @@ builder.Services.AddTransient<SessionMiddleware>();
 
 var app = builder.Build();
 
+app.UseAuthentication();
+app.UseAuthorization();
+
 using (var scope = app.Services.CreateScope())
 {
     var services = scope.ServiceProvider;
@@ -88,7 +90,7 @@ app.MapControllers();
 
 app.Run();
 
-void ConfigurePipeline(WebApplication app)
+static void ConfigurePipeline(WebApplication app)
 {
     app.MapSwagger("/openapi/{documentName}.json");
     app.MapScalarApiReference();

--- a/CareGuide.Core/Interfaces/IPersonAnnotationService.cs
+++ b/CareGuide.Core/Interfaces/IPersonAnnotationService.cs
@@ -4,11 +4,11 @@ namespace CareGuide.Core.Interfaces
 {
     public interface IPersonAnnotationService
     {
-        Task<List<PersonAnnotationDto>> GetAllByPersonAsync(Guid personId, int page, int pageSize, CancellationToken cancellationToken);
+        Task<List<PersonAnnotationDto>> GetAllByPersonAsync(int page, int pageSize, CancellationToken cancellationToken);
         Task<PersonAnnotationDto> GetAsync(Guid id, CancellationToken cancellationToken);
         Task<PersonAnnotationDto> CreateAsync(CreatePersonAnnotationDto personAnnotation, CancellationToken cancellationToken);
         Task<PersonAnnotationDto> UpdateAsync(Guid id, UpdatePersonAnnotationDto personAnnotation, CancellationToken cancellationToken);
-        Task DeleteAllByPersonAsync(Guid personId, CancellationToken cancellationToken);
+        Task DeleteAllByPersonAsync(CancellationToken cancellationToken);
         Task DeleteByIdsAsync(List<Guid> ids, CancellationToken cancellationToken);
     }
 }

--- a/CareGuide.Core/Services/AccountService.cs
+++ b/CareGuide.Core/Services/AccountService.cs
@@ -43,7 +43,7 @@ namespace CareGuide.Core.Services
 
                 UserDto user = await _userService.CreateAsync(person, createUserDtoWithPerson, cancellationToken);
 
-                string token = _jwtService.GenerateToken(user.Id, user.Email);
+                string token = _jwtService.GenerateToken(user.Id, person.Id, user.Email);
 
                 await _unitOfWork.CommitTransactionAsync(cancellationToken);
 
@@ -53,8 +53,7 @@ namespace CareGuide.Core.Services
                     token,
                     person.Name,
                     person.Gender,
-                    person.Birthday,
-                    person.Picture
+                    person.Birthday
                 );
             }
             catch (Exception)
@@ -71,7 +70,7 @@ namespace CareGuide.Core.Services
             if (user == null || !PasswordManager.ValidatePassword(loginAccount.Password, user.Password))
                 throw new InvalidOperationException("Wrong password or email");
 
-            string token = _jwtService.GenerateToken(user.Id, loginAccount.Email);
+            string token = _jwtService.GenerateToken(user.Id, user.PersonId, loginAccount.Email);
 
             UserDto userDto = await _userService.GetByIdDtoAsync(user.Id, cancellationToken);
             PersonDto personDto = await _personService.GetAsync(userDto.PersonId, cancellationToken);
@@ -82,8 +81,7 @@ namespace CareGuide.Core.Services
                 token,
                 personDto.Name,
                 personDto.Gender,
-                personDto.Birthday,
-                personDto.Picture
+                personDto.Birthday
             );
         }
 

--- a/CareGuide.Models/DTOs/Account/AccountDto.cs
+++ b/CareGuide.Models/DTOs/Account/AccountDto.cs
@@ -8,7 +8,6 @@ namespace CareGuide.Models.DTOs.Auth
         string SessionToken,
         string Name,
         Gender Gender,
-        DateOnly Birthday,
-        string? Picture
+        DateOnly Birthday
     );
 }

--- a/CareGuide.Models/DTOs/Person/PersonDto.cs
+++ b/CareGuide.Models/DTOs/Person/PersonDto.cs
@@ -7,6 +7,8 @@ namespace CareGuide.Models.DTOs.Person
         string Name,
         string? Picture,
         Gender Gender,
-        DateOnly Birthday
+        DateOnly Birthday,
+        DateTime CreatedAt,
+        DateTime UpdatedAt
     );
 }

--- a/CareGuide.Models/DTOs/PersonAnnotation/CreatePersonAnnotationDto.cs
+++ b/CareGuide.Models/DTOs/PersonAnnotation/CreatePersonAnnotationDto.cs
@@ -1,7 +1,6 @@
 ﻿namespace CareGuide.Models.DTOs.PersonAnnotation
 {
     public record CreatePersonAnnotationDto(
-        Guid PersonId,
         string Details,
         string? FileUrl
     );

--- a/CareGuide.Models/DTOs/PersonAnnotation/PersonAnnotationDto.cs
+++ b/CareGuide.Models/DTOs/PersonAnnotation/PersonAnnotationDto.cs
@@ -4,6 +4,8 @@
         Guid Id,
         Guid PersonId,
         string Details,
-        string? FileUrl
+        string? FileUrl,
+        DateTime CreatedAt,
+        DateTime UpdatedAt
     );
 }

--- a/CareGuide.Models/DTOs/PersonAnnotation/UpdatePersonAnnotationDto.cs
+++ b/CareGuide.Models/DTOs/PersonAnnotation/UpdatePersonAnnotationDto.cs
@@ -2,7 +2,6 @@
 {
     public record UpdatePersonAnnotationDto(
         Guid Id,
-        Guid PersonId,
         string Details,
         string? FileUrl
     );

--- a/CareGuide.Models/DTOs/User/UserDto.cs
+++ b/CareGuide.Models/DTOs/User/UserDto.cs
@@ -3,6 +3,8 @@
     public record UserDto(
         Guid Id,
         Guid PersonId,
-        string Email
+        string Email,
+        DateTime CreatedAt,
+        DateTime UpdatedAt
     );
 }

--- a/CareGuide.Models/Mappers/PersonAnnotation/PersonAnnotationProfileMapper.cs
+++ b/CareGuide.Models/Mappers/PersonAnnotation/PersonAnnotationProfileMapper.cs
@@ -9,6 +9,8 @@ namespace CareGuide.Models.Mappers
         public PersonAnnotationProfileMapper()
         {
             CreateMap<PersonAnnotation, PersonAnnotationDto>();
+            CreateMap<CreatePersonAnnotationDto, PersonAnnotation>();
+            CreateMap<UpdatePersonAnnotationDto, PersonAnnotation>();
         }
     }
 }

--- a/CareGuide.Models/Validators/PersonAnnotation/CreatePersonAnnotationDtoValidator.cs
+++ b/CareGuide.Models/Validators/PersonAnnotation/CreatePersonAnnotationDtoValidator.cs
@@ -1,16 +1,12 @@
 ﻿namespace CareGuide.Models.Validators.PersonAnnotation
 {
-    using FluentValidation;
     using CareGuide.Models.DTOs.PersonAnnotation;
+    using FluentValidation;
 
     public class CreatePersonAnnotationDtoValidator : AbstractValidator<CreatePersonAnnotationDto>
     {
         public CreatePersonAnnotationDtoValidator()
         {
-            RuleFor(x => x.PersonId)
-                .NotEmpty().WithMessage("PersonId is required.")
-                .NotEqual(Guid.Empty).WithMessage("PersonId cannot be an empty Guid.");
-
             RuleFor(x => x.Details)
                 .NotEmpty().WithMessage("Details is required.")
                 .MaximumLength(1000).WithMessage("Details must be at most 1000 characters.");

--- a/CareGuide.Models/Validators/PersonAnnotation/UpdatePersonAnnotationDtoValidator.cs
+++ b/CareGuide.Models/Validators/PersonAnnotation/UpdatePersonAnnotationDtoValidator.cs
@@ -1,7 +1,7 @@
 ﻿namespace CareGuide.Models.Validators.PersonAnnotation
 {
-    using FluentValidation;
     using CareGuide.Models.DTOs.PersonAnnotation;
+    using FluentValidation;
 
     public class UpdatePersonAnnotationDtoValidator : AbstractValidator<UpdatePersonAnnotationDto>
     {
@@ -10,10 +10,6 @@
             RuleFor(x => x.Id)
                 .NotEmpty().WithMessage("Id is required.")
                 .NotEqual(Guid.Empty).WithMessage("Id cannot be an empty Guid.");
-
-            RuleFor(x => x.PersonId)
-                .NotEmpty().WithMessage("PersonId is required.")
-                .NotEqual(Guid.Empty).WithMessage("PersonId cannot be an empty Guid.");
 
             RuleFor(x => x.Details)
                 .NotEmpty().WithMessage("Details is required.")

--- a/CareGuide.Security/Interfaces/IJwtService.cs
+++ b/CareGuide.Security/Interfaces/IJwtService.cs
@@ -4,7 +4,7 @@ namespace CareGuide.Security.Interfaces
 {
     public interface IJwtService
     {
-        string GenerateToken(Guid userId, string email);
+        string GenerateToken(Guid userId, Guid personId, string email);
         JwtSecurityToken? ValidateToken(string token);
     }
 }

--- a/CareGuide.Security/Interfaces/IUserSessionContext.cs
+++ b/CareGuide.Security/Interfaces/IUserSessionContext.cs
@@ -3,5 +3,7 @@
     public interface IUserSessionContext
     {
         Guid UserId { get; }
+        Guid PersonId { get; }
+        string Email { get; }
     }
 }

--- a/CareGuide.Security/JwtService.cs
+++ b/CareGuide.Security/JwtService.cs
@@ -19,7 +19,7 @@ namespace CareGuide.Security
             _audience = settings.Audience;
         }
 
-        public string GenerateToken(Guid userId, string email)
+        public string GenerateToken(Guid userId, Guid personId, string email)
         {
             SymmetricSecurityKey key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(_secretKey));
             SigningCredentials creds = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
@@ -29,6 +29,7 @@ namespace CareGuide.Security
                 claims: new List<Claim>
                 {
                     new Claim(JwtRegisteredClaimNames.Sub, userId.ToString()),
+                    new Claim("personId", personId.ToString()),
                     new Claim(JwtRegisteredClaimNames.Email, email),
                     new Claim(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString())
                 },

--- a/CareGuide.Security/UserSessionContext.cs
+++ b/CareGuide.Security/UserSessionContext.cs
@@ -1,34 +1,51 @@
 ﻿using CareGuide.Security.Interfaces;
 using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.Primitives;
-using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
 
 namespace CareGuide.Security
 {
-    public class UserSessionContext: IUserSessionContext
+    public class UserSessionContext : IUserSessionContext
     {
-        public readonly Guid? _userId;
-        public Guid UserId { 
-            get { 
-                return _userId ?? throw new UnauthorizedAccessException();
-            } 
-        }
+        public Guid UserId { get; }
+        public Guid PersonId { get; }
+        public string Email { get; }
 
         public UserSessionContext(IHttpContextAccessor httpContextAccessor, IJwtService jwtService)
         {
-            if (httpContextAccessor.HttpContext?.Request.Headers.TryGetValue("Authorization", out StringValues headerAuth) == true)
-            {
-                JwtSecurityToken? token = jwtService.ValidateToken(headerAuth.ToString().Replace("Bearer ", ""));
+            var httpContext = httpContextAccessor.HttpContext;
 
-                if (token != null)
-                {
-                    string? claimValue = token.Claims.ToList().Find((e) => e.Type == "sub")?.Value;
-                    if(claimValue != null) _userId = Guid.Parse(claimValue);
-                }
+            if (httpContext == null)
+                throw new UnauthorizedAccessException("No HttpContext available.");
 
-            }
+            if (!httpContext.Request.Headers.TryGetValue("Authorization", out var headerAuth))
+                throw new UnauthorizedAccessException("Authorization header not found.");
 
+            var token = jwtService.ValidateToken(headerAuth.ToString().Replace("Bearer ", ""));
+
+            if (token == null)
+                throw new UnauthorizedAccessException("Invalid or expired token.");
+
+            UserId = GetGuidClaim(token.Claims, "sub", "UserId");
+            PersonId = GetGuidClaim(token.Claims, "personId", "PersonId");
+            Email = GetStringClaim(token.Claims, "email");
         }
 
+        private static Guid GetGuidClaim(IEnumerable<Claim> claims, string type, string name)
+        {
+            var value = claims.FirstOrDefault(c => c.Type == type)?.Value;
+
+            if (value == null)
+                throw new UnauthorizedAccessException($"{name} claim ('{type}') not found in token.");
+
+            if (!Guid.TryParse(value, out var guid))
+                throw new UnauthorizedAccessException($"{name} claim ('{type}') is not a valid GUID: {value}");
+
+            return guid;
+        }
+
+        private static string GetStringClaim(IEnumerable<Claim> claims, string type)
+        {
+            return claims.FirstOrDefault(c => c.Type == type)?.Value ?? string.Empty;
+        }
     }
 }

--- a/CareGuide.Tests/Context/UserSessionContextTests.cs
+++ b/CareGuide.Tests/Context/UserSessionContextTests.cs
@@ -7,8 +7,10 @@ namespace CareGuide.Tests.Context
     public class UserSessionContextTests : IUserSessionContext
     {
         public Guid UserId { get; set; }
+        public Guid PersonId { get; set; }
+        public string Email { get; set; }
 
-        public UserSessionContextTests(IAccountService _accountService)
+        public UserSessionContextTests(IAccountService _accountService, IUserService _userService)
         {
             AccountDto account = _accountService.LoginAccountAsync(
                 new LoginAccountDto("test123@domaintest.com.br", "Test123"),
@@ -16,6 +18,10 @@ namespace CareGuide.Tests.Context
             ).Result;
 
             UserId = account.Id;
+            Email = account.Email;
+
+            var userDto = _userService.GetByIdDtoAsync(account.Id, CancellationToken.None).Result;
+            PersonId = userDto.PersonId;
         }
     }
 }


### PR DESCRIPTION
- Refactored `PersonAnnotation` endpoints to remove `personId` from requests, now using the `personId` from the authenticated user session
- Updated `UserSessionContext` and JWT authentication logic for better session management
- Renamed and clarified endpoints for deleting user-specific annotations
- Adjusted and created new mappers for `PersonAnnotation` to support the new flow
- Improved code organization and followed RESTful best practices