### PR TITLE
Add Doctor entity, endpoints, service, repository, and migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,9 @@ Esta solução tem como objetivo centralizar todas as informações relevantes a
 ## Principais Funcionalidades
 
 - **Gerenciar Usuários**: Cadastro de informações e login;
-- **Gerenciar Médicos**: Cadastro de médicos (TO DO);
-- **Gerenciar Anotações**: Cadastro de anotações importantes (TO DO);
+- **Gerenciar Pessoas**: Cadastro de todas as informações referentes a pessoa/usuário;
+- **Gerenciar Médicos**: Cadastro de médicos;
+- **Gerenciar Anotações**: Cadastro de anotações importantes;
 - **Agenda/Calendário**: Cadastro de eventos em uma agenda/calendário (TO DO);
 
 ## Tecnologias Utilizadas

--- a/src/CareGuide.API/Endpoints/DoctorEndpoints.cs
+++ b/src/CareGuide.API/Endpoints/DoctorEndpoints.cs
@@ -1,0 +1,104 @@
+﻿using CareGuide.API.Endpoints.Shared;
+using CareGuide.API.Extensions;
+using CareGuide.Core.Interfaces;
+using CareGuide.Models.Constants;
+using CareGuide.Models.DTOs.Doctor;
+using Microsoft.AspNetCore.Mvc;
+
+namespace CareGuide.API.Endpoints
+{
+    public class DoctorEndpoints() : IEndpoint
+    {
+        public void RegisterEndpoints(IEndpointRouteBuilder endpoints)
+        {
+            var group = endpoints
+                .MapGroup("/doctors")
+                .WithTags("Doctors")
+                .WithDefaultProblemResponses();
+
+            group.MapGet("/", GetAll)
+                 .WithName("GetAllDoctors")
+                 .WithSummary("Get all doctors")
+                 .WithDescription("Retrieves all doctors for the authenticated person using pagination parameters.")
+                 .Produces<List<DoctorDto>>(StatusCodes.Status200OK)
+                 .ProducesProblem(StatusCodes.Status400BadRequest);
+
+            group.MapGet("/{id:guid}", GetById)
+                 .WithName("GetDoctorById")
+                 .WithSummary("Get doctor by id")
+                 .WithDescription("Retrieves a specific doctor for the authenticated person by its identifier.")
+                 .Produces<DoctorDto>(StatusCodes.Status200OK)
+                 .ProducesProblem(StatusCodes.Status404NotFound);
+
+            group.MapPost("/", Create)
+                 .WithName("CreateDoctor")
+                 .WithSummary("Create doctor")
+                 .WithDescription("Creates a new doctor for the authenticated person.")
+                 .Accepts<CreateDoctorDto>("application/json")
+                 .Produces<DoctorDto>(StatusCodes.Status201Created)
+                 .ProducesProblem(StatusCodes.Status400BadRequest);
+
+            group.MapPut("/{id:guid}", Update)
+                 .WithName("UpdateDoctor")
+                 .WithSummary("Update doctor")
+                 .WithDescription("Updates an existing doctor for the authenticated person by its identifier.")
+                 .Accepts<UpdateDoctorDto>("application/json")
+                 .Produces<DoctorDto>(StatusCodes.Status200OK)
+                 .ProducesProblem(StatusCodes.Status400BadRequest)
+                 .ProducesProblem(StatusCodes.Status404NotFound);
+
+            group.MapDelete("/person", DeleteAll)
+                 .WithName("DeleteAllDoctors")
+                 .WithSummary("Delete all doctors")
+                 .WithDescription("Deletes all doctors associated with the authenticated person.")
+                 .Produces(StatusCodes.Status204NoContent);
+
+            group.MapDelete("/", DeleteByIds)
+                 .WithName("DeleteDoctorsByIds")
+                 .WithSummary("Delete multiple doctors")
+                 .WithDescription("Deletes multiple doctors for the authenticated person using a list of doctor identifiers provided in the request body.")
+                 .Accepts<List<Guid>>("application/json")
+                 .Produces(StatusCodes.Status204NoContent)
+                 .ProducesProblem(StatusCodes.Status400BadRequest);
+        }
+
+        private static async Task<IResult> GetAll(int page, int pageSize, IDoctorService doctorService, CancellationToken cancellationToken)
+        {
+            page = page == 0 ? PaginationConstants.DefaultPage : page;
+            pageSize = pageSize == 0 ? PaginationConstants.DefaultPageSize : pageSize;
+
+            var result = await doctorService.GetAllByPersonAsync(page, pageSize, cancellationToken);
+            return Results.Ok(result);
+        }
+
+        private static async Task<IResult> GetById(Guid id, IDoctorService doctorService, CancellationToken cancellationToken)
+        {
+            var result = await doctorService.GetAsync(id, cancellationToken);
+            return Results.Ok(result);
+        }
+
+        private static async Task<IResult> Create(CreateDoctorDto createDoctorDto, IDoctorService doctorService, CancellationToken cancellationToken)
+        {
+            var created = await doctorService.CreateAsync(createDoctorDto, cancellationToken);
+            return Results.Created($"/doctors/{created.Id}", created);
+        }
+
+        private static async Task<IResult> Update(Guid id, UpdateDoctorDto updateDoctorDto, IDoctorService doctorService, CancellationToken cancellationToken)
+        {
+            var result = await doctorService.UpdateAsync(id, updateDoctorDto, cancellationToken);
+            return Results.Ok(result);
+        }
+
+        private static async Task<IResult> DeleteAll(IDoctorService doctorService, CancellationToken cancellationToken)
+        {
+            await doctorService.DeleteAllByPersonAsync(cancellationToken);
+            return Results.NoContent();
+        }
+
+        private static async Task<IResult> DeleteByIds([FromBody] List<Guid> ids, IDoctorService doctorService, CancellationToken cancellationToken)
+        {
+            await doctorService.DeleteByIdsAsync(ids, cancellationToken);
+            return Results.NoContent();
+        }
+    }
+}

--- a/src/CareGuide.Core/DependencyInjection.cs
+++ b/src/CareGuide.Core/DependencyInjection.cs
@@ -17,6 +17,7 @@ namespace CareGuide.Core
             services.AddScoped<IPersonPhoneService, PersonPhoneService>();
             services.AddScoped<IPersonDiseaseService, PersonDiseaseService>();
             services.AddScoped<IPersonFamilyHistoryService, PersonFamilyHistoryService>();
+            services.AddScoped<IDoctorService, DoctorService>();
             services.AddScoped<IRefreshTokenService, RefreshTokenService>();
 
             return services;

--- a/src/CareGuide.Core/Interfaces/IDoctorService.cs
+++ b/src/CareGuide.Core/Interfaces/IDoctorService.cs
@@ -1,0 +1,14 @@
+﻿using CareGuide.Models.DTOs.Doctor;
+
+namespace CareGuide.Core.Interfaces
+{
+    public interface IDoctorService
+    {
+        Task<List<DoctorDto>> GetAllByPersonAsync(int page, int pageSize, CancellationToken cancellationToken);
+        Task<DoctorDto> GetAsync(Guid id, CancellationToken cancellationToken);
+        Task<DoctorDto> CreateAsync(CreateDoctorDto doctor, CancellationToken cancellationToken);
+        Task<DoctorDto> UpdateAsync(Guid id, UpdateDoctorDto doctor, CancellationToken cancellationToken);
+        Task DeleteAllByPersonAsync(CancellationToken cancellationToken);
+        Task DeleteByIdsAsync(List<Guid> ids, CancellationToken cancellationToken);
+    }
+}

--- a/src/CareGuide.Core/Services/DoctorService.cs
+++ b/src/CareGuide.Core/Services/DoctorService.cs
@@ -1,0 +1,81 @@
+﻿using AutoMapper;
+using CareGuide.Core.Interfaces;
+using CareGuide.Infra.Interfaces;
+using CareGuide.Models.DTOs.Doctor;
+using CareGuide.Models.Entities;
+
+namespace CareGuide.Core.Services
+{
+    public class DoctorService : IDoctorService
+    {
+        private readonly IDoctorRepository _doctorRepository;
+        private readonly IMapper _mapper;
+
+        public DoctorService(IDoctorRepository doctorRepository, IMapper mapper)
+        {
+            _doctorRepository = doctorRepository;
+            _mapper = mapper;
+        }
+
+        public async Task<List<DoctorDto>> GetAllByPersonAsync(int page, int pageSize, CancellationToken cancellationToken)
+        {
+            var list = await _doctorRepository.GetAllByPersonAsync(page, pageSize, cancellationToken);
+            return _mapper.Map<List<DoctorDto>>(list);
+        }
+
+        public async Task<DoctorDto> GetAsync(Guid id, CancellationToken cancellationToken)
+        {
+            if (id == Guid.Empty)
+                throw new ArgumentException("The id cannot be empty.", nameof(id));
+
+            var entity = await _doctorRepository.GetAsync(id, cancellationToken);
+
+            if (entity == null)
+                throw new KeyNotFoundException($"No doctor found with the ID {id}.");
+
+            return _mapper.Map<DoctorDto>(entity);
+        }
+
+        public async Task<DoctorDto> CreateAsync(CreateDoctorDto doctor, CancellationToken cancellationToken)
+        {
+            if (doctor == null)
+                throw new ArgumentNullException(nameof(doctor));
+
+            var entity = _mapper.Map<Doctor>(doctor);
+
+            await _doctorRepository.AddAsync(entity, cancellationToken);
+
+            return _mapper.Map<DoctorDto>(entity);
+        }
+
+        public async Task<DoctorDto> UpdateAsync(Guid id, UpdateDoctorDto doctor, CancellationToken cancellationToken)
+        {
+            if (id == Guid.Empty)
+                throw new ArgumentException("The id cannot be empty.", nameof(id));
+
+            if (doctor == null)
+                throw new ArgumentNullException(nameof(doctor));
+
+            var existing = await _doctorRepository.GetAsync(id, cancellationToken);
+
+            if (existing == null)
+                throw new KeyNotFoundException($"No doctor found with the ID {id}.");
+
+            existing.Name = doctor.Name;
+            existing.Details = doctor.Details;
+
+            var updated = await _doctorRepository.UpdateAsync(existing, cancellationToken);
+            return _mapper.Map<DoctorDto>(updated);
+        }
+
+        public async Task DeleteAllByPersonAsync(CancellationToken cancellationToken)
+        {
+            await _doctorRepository.DeleteAllByPersonAsync(cancellationToken);
+        }
+
+        public async Task DeleteByIdsAsync(List<Guid> ids, CancellationToken cancellationToken)
+        {
+            await _doctorRepository.DeleteManyAsync(ids, cancellationToken);
+        }
+    }
+}

--- a/src/CareGuide.Infra/Contexts/DatabaseContext.cs
+++ b/src/CareGuide.Infra/Contexts/DatabaseContext.cs
@@ -24,6 +24,7 @@ namespace CareGuide.Infra.Contexts
         public DbSet<PersonPhone> PersonPhones { get; set; } = null!;
         public DbSet<PersonDisease> PersonDiseases { get; set; } = null!;
         public DbSet<PersonFamilyHistory> PersonFamilyHistories { get; set; } = null!;
+        public DbSet<Doctor> Doctors { get; set; } = null!;
         public DbSet<RefreshToken> RefreshTokens { get; set; } = null!;
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
@@ -36,6 +37,7 @@ namespace CareGuide.Infra.Contexts
             modelBuilder.ApplyConfiguration(new PhoneMapping());
             modelBuilder.ApplyConfiguration(new PersonPhoneMapping());
             modelBuilder.ApplyConfiguration(new PersonFamilyHistoryMapping());
+            modelBuilder.ApplyConfiguration(new DoctorMapping());
             modelBuilder.ApplyConfiguration(new RefreshTokenMapping());
 
             if (_userSessionContext != null && _userSessionContext.PersonId != Guid.Empty)

--- a/src/CareGuide.Infra/DependencyInjection.cs
+++ b/src/CareGuide.Infra/DependencyInjection.cs
@@ -42,6 +42,7 @@ namespace CareGuide.Infra
             services.AddScoped<IPersonPhoneRepository, PersonPhoneRepository>();
             services.AddScoped<IPersonDiseaseRepository, PersonDiseaseRepository>();
             services.AddScoped<IPersonFamilyHistoryRepository, PersonFamilyHistoryRepository>();
+            services.AddScoped<IDoctorRepository, DoctorRepository>();
             services.AddScoped<IRefreshTokenRepository, RefreshTokenRepository>();
         }
     }

--- a/src/CareGuide.Infra/Interfaces/IDoctorRepository.cs
+++ b/src/CareGuide.Infra/Interfaces/IDoctorRepository.cs
@@ -1,0 +1,9 @@
+﻿using CareGuide.Infra.Interfaces.Shared;
+using CareGuide.Models.Entities;
+
+namespace CareGuide.Infra.Interfaces
+{
+    public interface IDoctorRepository : IBasePersonOwnedRepository<Doctor>
+    {
+    }
+}

--- a/src/CareGuide.Infra/Mappings/DoctorMapping.cs
+++ b/src/CareGuide.Infra/Mappings/DoctorMapping.cs
@@ -1,0 +1,26 @@
+﻿using CareGuide.Models.Constants;
+using CareGuide.Models.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace CareGuide.Infra.Mappings
+{
+    public class DoctorMapping : IEntityTypeConfiguration<Doctor>
+    {
+        public void Configure(EntityTypeBuilder<Doctor> builder)
+        {
+            builder.ToTable("doctors");
+            builder.HasKey(x => x.Id);
+
+            builder.Property(x => x.Id).HasColumnName("id");
+            builder.Property(x => x.PersonId).IsRequired().HasColumnName("person_id");
+            builder.Property(x => x.Name).IsRequired().HasMaxLength(DatabaseConstants.MaxLengthStandardText).HasColumnName("name");
+            builder.Property(x => x.Details).HasColumnType("text").HasMaxLength(DatabaseConstants.MaxLengthLargeText).HasColumnName("details");
+            builder.Property(x => x.CreatedAt).IsRequired().HasColumnName("created_at");
+            builder.Property(x => x.UpdatedAt).IsRequired().HasColumnName("updated_at");
+            builder.Property(x => x.IsActive).IsRequired().HasDefaultValue(true).HasColumnName("is_active");
+
+            builder.HasOne(x => x.Person).WithMany(x => x.Doctors).HasForeignKey(x => x.PersonId).HasConstraintName("fk_doctor_person").OnDelete(DeleteBehavior.Cascade);
+        }
+    }
+}

--- a/src/CareGuide.Infra/Migrations/20260403163718_AddDoctorTable.Designer.cs
+++ b/src/CareGuide.Infra/Migrations/20260403163718_AddDoctorTable.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using CareGuide.Infra.Contexts;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace CareGuide.Infra.Migrations
 {
     [DbContext(typeof(DatabaseContext))]
-    partial class DatabaseContextModelSnapshot : ModelSnapshot
+    [Migration("20260403163718_AddDoctorTable")]
+    partial class AddDoctorTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/CareGuide.Infra/Migrations/20260403163718_AddDoctorTable.cs
+++ b/src/CareGuide.Infra/Migrations/20260403163718_AddDoctorTable.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CareGuide.Infra.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddDoctorTable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "doctors",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    person_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    name = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: false),
+                    details = table.Column<string>(type: "text", maxLength: 1000, nullable: true),
+                    created_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    updated_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    is_active = table.Column<bool>(type: "boolean", nullable: false, defaultValue: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_doctors", x => x.id);
+                    table.ForeignKey(
+                        name: "fk_doctor_person",
+                        column: x => x.person_id,
+                        principalTable: "persons",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_doctors_person_id",
+                table: "doctors",
+                column: "person_id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "doctors");
+        }
+    }
+}

--- a/src/CareGuide.Infra/Repositories/DoctorRepository.cs
+++ b/src/CareGuide.Infra/Repositories/DoctorRepository.cs
@@ -1,0 +1,18 @@
+﻿using CareGuide.Infra.Contexts;
+using CareGuide.Infra.Interfaces;
+using CareGuide.Infra.Repositories.Shared;
+using CareGuide.Models.Entities;
+using CareGuide.Security.Interfaces;
+
+namespace CareGuide.Infra.Repositories
+{
+    public class DoctorRepository : BasePersonOwnedRepository<Doctor>, IDoctorRepository
+    {
+        private readonly DatabaseContext _context;
+
+        public DoctorRepository(DatabaseContext context, IUserSessionContext userSessionContext) : base(context, userSessionContext)
+        {
+            _context = context;
+        }
+    }
+}

--- a/src/CareGuide.Models/DTOs/Doctor/CreateDoctorDto.cs
+++ b/src/CareGuide.Models/DTOs/Doctor/CreateDoctorDto.cs
@@ -1,0 +1,7 @@
+﻿namespace CareGuide.Models.DTOs.Doctor
+{
+    public record CreateDoctorDto(
+        string Name,
+        string? Details
+    );
+}

--- a/src/CareGuide.Models/DTOs/Doctor/DoctorDto.cs
+++ b/src/CareGuide.Models/DTOs/Doctor/DoctorDto.cs
@@ -1,0 +1,11 @@
+﻿namespace CareGuide.Models.DTOs.Doctor
+{
+    public record DoctorDto(
+        Guid Id,
+        Guid PersonId,
+        string Name,
+        string? Details,
+        DateTime CreatedAt,
+        DateTime UpdatedAt
+    );
+}

--- a/src/CareGuide.Models/DTOs/Doctor/UpdateDoctorDto.cs
+++ b/src/CareGuide.Models/DTOs/Doctor/UpdateDoctorDto.cs
@@ -1,0 +1,8 @@
+﻿namespace CareGuide.Models.DTOs.Doctor
+{
+    public record UpdateDoctorDto(
+        Guid Id,
+        string Name,
+        string? Details
+    );
+}

--- a/src/CareGuide.Models/DependencyInjection.cs
+++ b/src/CareGuide.Models/DependencyInjection.cs
@@ -1,4 +1,5 @@
-﻿using CareGuide.Models.Mappers.Person;
+﻿using CareGuide.Models.Mappers.Doctor;
+using CareGuide.Models.Mappers.Person;
 using CareGuide.Models.Mappers.PersonAnnotation;
 using CareGuide.Models.Mappers.PersonDisease;
 using CareGuide.Models.Mappers.PersonFamilyHistory;
@@ -26,6 +27,7 @@ namespace CareGuide.Models
                 cfg.AddProfile<PhoneProfileMapper>();
                 cfg.AddProfile<PersonPhoneProfileMapper>();
                 cfg.AddProfile<PersonDiseaseProfileMapper>();
+                cfg.AddProfile<DoctorProfileMapper>();
                 cfg.AddProfile<PersonFamilyHistoryProfileMapper>();
             });
 

--- a/src/CareGuide.Models/Entities/Doctor.cs
+++ b/src/CareGuide.Models/Entities/Doctor.cs
@@ -1,0 +1,13 @@
+﻿using CareGuide.Models.Entities.Shared;
+
+namespace CareGuide.Models.Entities
+{
+    public class Doctor : Entity, IPersonOwnedEntity
+    {
+        public required Guid? PersonId { get; set; }
+        public required string Name { get; set; }
+        public string? Details { get; set; }
+
+        public Person Person { get; set; } = null!;
+    }
+}

--- a/src/CareGuide.Models/Entities/Person.cs
+++ b/src/CareGuide.Models/Entities/Person.cs
@@ -16,5 +16,6 @@ namespace CareGuide.Models.Entities
         public ICollection<PersonPhone> PersonPhones { get; set; } = new List<PersonPhone>();
         public ICollection<PersonDisease> PersonDiseases { get; set; } = new List<PersonDisease>();
         public ICollection<PersonFamilyHistory> PersonFamilyHistories { get; set; } = new List<PersonFamilyHistory>();
+        public ICollection<Doctor> Doctors { get; set; } = new List<Doctor>();
     }
 }

--- a/src/CareGuide.Models/Mappers/Doctor/DoctorProfileMapper.cs
+++ b/src/CareGuide.Models/Mappers/Doctor/DoctorProfileMapper.cs
@@ -1,0 +1,15 @@
+﻿using AutoMapper;
+using CareGuide.Models.DTOs.Doctor;
+
+namespace CareGuide.Models.Mappers.Doctor
+{
+    public class DoctorProfileMapper : Profile
+    {
+        public DoctorProfileMapper()
+        {
+            CreateMap<Entities.Doctor, DoctorDto>();
+            CreateMap<CreateDoctorDto, Entities.Doctor>();
+            CreateMap<UpdateDoctorDto, Entities.Doctor>();
+        }
+    }
+}

--- a/src/CareGuide.Models/Validators/Doctor/CreateDoctorDtoValidator.cs
+++ b/src/CareGuide.Models/Validators/Doctor/CreateDoctorDtoValidator.cs
@@ -1,0 +1,22 @@
+﻿using CareGuide.Models.Constants;
+using CareGuide.Models.DTOs.Doctor;
+using FluentValidation;
+
+namespace CareGuide.Models.Validators.Doctor
+{
+    public class CreateDoctorDtoValidator : AbstractValidator<CreateDoctorDto>
+    {
+        public CreateDoctorDtoValidator()
+        {
+            RuleFor(x => x.Name)
+                .NotEmpty().WithMessage("Name is required.")
+                .MaximumLength(DatabaseConstants.MaxLengthStandardText)
+                .WithMessage($"Name must not exceed {DatabaseConstants.MaxLengthStandardText} characters.");
+
+            RuleFor(x => x.Details)
+                .MaximumLength(DatabaseConstants.MaxLengthLargeText)
+                .WithMessage($"Details must not exceed {DatabaseConstants.MaxLengthLargeText} characters.")
+                .When(x => !string.IsNullOrWhiteSpace(x.Details));
+        }
+    }
+}

--- a/src/CareGuide.Models/Validators/Doctor/UpdateDoctorDtoValidator.cs
+++ b/src/CareGuide.Models/Validators/Doctor/UpdateDoctorDtoValidator.cs
@@ -1,0 +1,25 @@
+﻿using CareGuide.Models.Constants;
+using CareGuide.Models.DTOs.Doctor;
+using FluentValidation;
+
+namespace CareGuide.Models.Validators.Doctor
+{
+    public class UpdateDoctorDtoValidator : AbstractValidator<UpdateDoctorDto>
+    {
+        public UpdateDoctorDtoValidator()
+        {
+            RuleFor(x => x.Id)
+                .NotEmpty().WithMessage("Id is required.");
+
+            RuleFor(x => x.Name)
+                .NotEmpty().WithMessage("Name is required.")
+                .MaximumLength(DatabaseConstants.MaxLengthStandardText)
+                .WithMessage($"Name must not exceed {DatabaseConstants.MaxLengthStandardText} characters.");
+
+            RuleFor(x => x.Details)
+                .MaximumLength(DatabaseConstants.MaxLengthLargeText)
+                .WithMessage($"Details must not exceed {DatabaseConstants.MaxLengthLargeText} characters.")
+                .When(x => !string.IsNullOrWhiteSpace(x.Details));
+        }
+    }
+}

--- a/src/CareGuide.Models/Validators/PersonDisease/CreatePersonDiseaseDtoValidator.cs
+++ b/src/CareGuide.Models/Validators/PersonDisease/CreatePersonDiseaseDtoValidator.cs
@@ -1,0 +1,24 @@
+﻿using CareGuide.Models.Constants;
+using CareGuide.Models.DTOs.PersonDisease;
+using FluentValidation;
+
+namespace CareGuide.Models.Validators.PersonDisease
+{
+    public class CreatePersonDiseaseDtoValidator : AbstractValidator<CreatePersonDiseaseDto>
+    {
+        public CreatePersonDiseaseDtoValidator()
+        {
+            RuleFor(x => x.Name)
+                .NotEmpty().WithMessage("Name is required.")
+                .MaximumLength(DatabaseConstants.MaxLengthStandardText).WithMessage($"Name must not exceed {DatabaseConstants.MaxLengthStandardText} characters.");
+
+            RuleFor(x => x.DiagnosisDate)
+                .LessThanOrEqualTo(DateOnly.FromDateTime(DateTime.Now))
+                .When(x => x.DiagnosisDate.HasValue)
+                .WithMessage("DiagnosisDate cannot be in the future.");
+
+            RuleFor(x => x.DiseaseType)
+                .IsInEnum().WithMessage("DiseaseType is invalid.");
+        }
+    }
+}

--- a/src/CareGuide.Models/Validators/PersonDisease/UpdatePersonDiseaseDtoValidator.cs
+++ b/src/CareGuide.Models/Validators/PersonDisease/UpdatePersonDiseaseDtoValidator.cs
@@ -1,0 +1,27 @@
+﻿using CareGuide.Models.Constants;
+using CareGuide.Models.DTOs.PersonDisease;
+using FluentValidation;
+
+namespace CareGuide.Models.Validators.PersonDisease
+{
+    public class UpdatePersonDiseaseDtoValidator : AbstractValidator<UpdatePersonDiseaseDto>
+    {
+        public UpdatePersonDiseaseDtoValidator()
+        {
+            RuleFor(x => x.Id)
+                .NotEmpty().WithMessage("Id is required.");
+
+            RuleFor(x => x.Name)
+                .NotEmpty().WithMessage("Name is required.")
+                .MaximumLength(DatabaseConstants.MaxLengthStandardText).WithMessage($"Name must not exceed {DatabaseConstants.MaxLengthStandardText} characters.");
+
+            RuleFor(x => x.DiagnosisDate)
+                .LessThanOrEqualTo(DateOnly.FromDateTime(DateTime.Now))
+                .When(x => x.DiagnosisDate.HasValue)
+                .WithMessage("DiagnosisDate cannot be in the future.");
+
+            RuleFor(x => x.DiseaseType)
+                .IsInEnum().WithMessage("DiseaseType is invalid.");
+        }
+    }
+}


### PR DESCRIPTION
This commit introduces full support for the Doctor entity in the CareGuide API. It includes:

- Creation of the Doctor entity, DTOs, validators, and AutoMapper profile.
- Implementation of Doctor endpoints for CRUD operations.
- Addition of `DoctorService` and `DoctorRepository` with dependency injection.
- Database migration and mapping for the doctors table.
- Updates to the `DatabaseContext` and Person entity to support doctor relationships.
- Configuration updates and new validators for related DTOs.

These changes enable management of doctor records associated with a person, including API endpoints, validation, and persistence.