### PR TITLE
Fix: Harden security layer across auth, rate limiting and dependencies

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -34,7 +34,10 @@
       "Bash(Get-Content \"C:\\\\Users\\\\amanda.maschio\\\\Documents\\\\PersonalRepos\\\\care-guide-api\\\\src\\\\CareGuide.Core\\\\Services\\\\PersonHealthService.cs\")",
       "Bash(Get-ChildItem -Path \"C:\\\\Users\\\\amanda.maschio\\\\Documents\\\\PersonalRepos\\\\care-guide-api\\\\src\\\\CareGuide.Security\" -Filter \"*.cs\" -Recurse)",
       "Bash(Select-Object -ExpandProperty FullName)",
-      "Bash(git mv *)"
+      "Bash(git mv *)",
+      "Bash(dotnet list *)",
+      "Bash(dotnet package *)",
+      "Bash(grep -v \"^$\")"
     ]
   }
 }

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,8 @@
+<Project>
+  <!-- Force patched version of System.Security.Cryptography.Xml across all projects.
+       Resolves CVE GHSA-37gx-xxp4-5rgx and GHSA-w3x6-4m5h-cxqf (transitive via Identity/JWT packages).
+       Excluded from CareGuide.API — it inherits the patched version transitively through project references. -->
+  <ItemGroup Condition="'$(MSBuildProjectName)' != 'CareGuide.API'">
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.8" />
+  </ItemGroup>
+</Project>

--- a/src/CareGuide.API/CareGuide.API.csproj
+++ b/src/CareGuide.API/CareGuide.API.csproj
@@ -8,13 +8,13 @@
 
   <ItemGroup>
     <PackageReference Include="FluentValidation" Version="12.1.1" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.5" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.5" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.5">
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.5">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/CareGuide.API/Endpoints/AccountEndpoints.cs
+++ b/src/CareGuide.API/Endpoints/AccountEndpoints.cs
@@ -1,4 +1,5 @@
-﻿using CareGuide.API.Endpoints.Shared;
+using CareGuide.API.Endpoints.Shared;
+using CareGuide.API.Extensions;
 using CareGuide.API.Helpers;
 using CareGuide.API.Middlewares;
 using CareGuide.Core.Interfaces;
@@ -18,6 +19,7 @@ public class AccountEndpoints() : IEndpoint
 
         group.MapPost("/", Create)
              .AllowAnonymous()
+             .RequireRateLimiting(RateLimitingExtension.AuthPolicy)
              .WithMetadata(new IgnoreSessionMiddleware())
              .WithSummary("Create Account")
              .WithDescription("Creates a new account by creating a Person for personal information and a User for account credentials.")
@@ -28,6 +30,7 @@ public class AccountEndpoints() : IEndpoint
 
         group.MapPost("/login", Login)
              .AllowAnonymous()
+             .RequireRateLimiting(RateLimitingExtension.AuthPolicy)
              .WithMetadata(new IgnoreSessionMiddleware())
              .WithSummary("Login")
              .WithDescription("Authenticates a user and returns a JWT token and a refresh token.")
@@ -43,6 +46,7 @@ public class AccountEndpoints() : IEndpoint
 
         group.MapPost("/refresh", Refresh)
              .AllowAnonymous()
+             .RequireRateLimiting(RateLimitingExtension.AuthPolicy)
              .WithMetadata(new IgnoreSessionMiddleware())
              .WithSummary("Refresh Token")
              .WithDescription("Refreshes JWT access token using a valid refresh token.")

--- a/src/CareGuide.API/Extensions/RateLimitingExtension.cs
+++ b/src/CareGuide.API/Extensions/RateLimitingExtension.cs
@@ -1,28 +1,72 @@
-﻿using System.Threading.RateLimiting;
+using System.Net;
+using System.Threading.RateLimiting;
 
 namespace CareGuide.API.Extensions
 {
     public static class RateLimitingExtension
     {
+        public const string AuthPolicy = "auth";
+        public const string GeneralPolicy = "general";
+
         public static IServiceCollection AddApiRateLimiting(this IServiceCollection services)
         {
             services.AddRateLimiter(options =>
             {
-                options.GlobalLimiter = PartitionedRateLimiter.Create<HttpContext, string>(httpContext =>
+                // General: sliding window, 60 req/min per IP
+                options.AddPolicy(GeneralPolicy, httpContext =>
+                    RateLimitPartition.GetSlidingWindowLimiter(
+                        partitionKey: ResolveClientIp(httpContext),
+                        factory: _ => new SlidingWindowRateLimiterOptions
+                        {
+                            PermitLimit = 60,
+                            Window = TimeSpan.FromMinutes(1),
+                            SegmentsPerWindow = 6,
+                            QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+                            QueueLimit = 0
+                        }));
+
+                // Auth: stricter fixed window — brute-force protection
+                options.AddPolicy(AuthPolicy, httpContext =>
                     RateLimitPartition.GetFixedWindowLimiter(
-                        partitionKey: httpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown",
+                        partitionKey: ResolveClientIp(httpContext),
                         factory: _ => new FixedWindowRateLimiterOptions
                         {
-                            PermitLimit = 10,
+                            PermitLimit = 5,
                             Window = TimeSpan.FromMinutes(1),
                             QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
                             QueueLimit = 0
                         }));
 
                 options.RejectionStatusCode = StatusCodes.Status429TooManyRequests;
+
+                options.OnRejected = async (context, cancellationToken) =>
+                {
+                    if (context.Lease.TryGetMetadata(MetadataName.RetryAfter, out var retryAfter))
+                    {
+                        context.HttpContext.Response.Headers.RetryAfter =
+                            ((int)retryAfter.TotalSeconds).ToString();
+                    }
+
+                    context.HttpContext.Response.StatusCode = StatusCodes.Status429TooManyRequests;
+                    await context.HttpContext.Response.WriteAsync(
+                        "Too many requests. Please try again later.", cancellationToken);
+                };
             });
 
             return services;
+        }
+
+        private static string ResolveClientIp(HttpContext context)
+        {
+            var forwarded = context.Request.Headers["X-Forwarded-For"].FirstOrDefault();
+            if (!string.IsNullOrWhiteSpace(forwarded))
+            {
+                var ip = forwarded.Split(',')[0].Trim();
+                if (IPAddress.TryParse(ip, out _))
+                    return ip;
+            }
+
+            return context.Connection.RemoteIpAddress?.ToString() ?? "unknown";
         }
     }
 }

--- a/src/CareGuide.API/Middlewares/SessionMiddleware.cs
+++ b/src/CareGuide.API/Middlewares/SessionMiddleware.cs
@@ -1,23 +1,15 @@
-﻿using CareGuide.Security.Interfaces;
 using Microsoft.AspNetCore.Authorization;
-using Microsoft.Extensions.Primitives;
 
 namespace CareGuide.API.Middlewares
 {
     public class SessionMiddleware : IMiddleware
     {
-        private readonly IJwtService _jwtService;
-
-        public SessionMiddleware(IJwtService jwtService)
-        {
-            _jwtService = jwtService;
-        }
-
         public async Task InvokeAsync(HttpContext context, RequestDelegate next)
         {
             var endpoint = context.GetEndpoint();
 
-            if (endpoint?.Metadata.GetMetadata<IgnoreSessionMiddleware>() is not null || endpoint?.Metadata.GetMetadata<IAllowAnonymous>() is not null)
+            if (endpoint?.Metadata.GetMetadata<IgnoreSessionMiddleware>() is not null ||
+                endpoint?.Metadata.GetMetadata<IAllowAnonymous>() is not null)
             {
                 await next(context);
                 return;
@@ -34,24 +26,8 @@ namespace CareGuide.API.Middlewares
                 return;
             }
 
-            if (!context.Request.Headers.TryGetValue("Authorization", out StringValues headerAuth))
-            {
-                throw new UnauthorizedAccessException("invalid token");
-            }
-
-            var authorizationHeader = headerAuth.ToString();
-
-            if (!authorizationHeader.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
-            {
-                throw new UnauthorizedAccessException("invalid token");
-            }
-
-            var token = authorizationHeader["Bearer ".Length..].Trim();
-
-            if (string.IsNullOrWhiteSpace(token) || _jwtService.ValidateToken(token) is null)
-            {
-                throw new UnauthorizedAccessException("invalid token");
-            }
+            if (context.User.Identity?.IsAuthenticated != true)
+                throw new UnauthorizedAccessException("Invalid or missing token.");
 
             await next(context);
         }

--- a/src/CareGuide.API/Program.cs
+++ b/src/CareGuide.API/Program.cs
@@ -7,6 +7,7 @@ using CareGuide.Models;
 using CareGuide.Models.Constants;
 using CareGuide.Security;
 using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.OpenApi;
 using Scalar.AspNetCore;
 
@@ -95,6 +96,11 @@ else
     app.UseHttpsRedirection();
 }
 
+app.UseForwardedHeaders(new ForwardedHeadersOptions
+{
+    ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto
+});
+
 app.UseMiddleware<ErrorHandlerMiddleware>();
 app.UseMiddleware<SecurityHeadersMiddleware>();
 
@@ -110,6 +116,7 @@ app.UseRateLimiter();
 
 app.MapGroup(ApiConstants.API_PREFIX)
    .RequireAuthorization()
+   .RequireRateLimiting(RateLimitingExtension.GeneralPolicy)
    .MapGroup(ApiConstants.API_VERSION)
    .AddEndpointFilterFactory(ValidationFilterFactory.Create)
    .MapAllEndpoints();

--- a/src/CareGuide.Core/Services/AccountService.cs
+++ b/src/CareGuide.Core/Services/AccountService.cs
@@ -46,7 +46,7 @@ namespace CareGuide.Core.Services
 
                 UserDto user = await _userService.CreateAsync(person, createUserDtoWithPerson, cancellationToken);
 
-                var accessToken = _jwtService.GenerateToken(user.Id, person.Id, user.Email);
+                var accessToken = _jwtService.GenerateToken(user.Id, person.Id);
                 var refreshToken = await _refreshTokenService.CreateAsync(user.Id, cancellationToken);
 
                 await _unitOfWork.CommitTransactionAsync(cancellationToken);
@@ -75,7 +75,7 @@ namespace CareGuide.Core.Services
             if (user == null || !PasswordManagerHelper.ValidatePassword(loginAccount.Password, user.Password))
                 throw new InvalidOperationException("Wrong password or email");
 
-            var accessToken = _jwtService.GenerateToken(user.Id, user.PersonId, loginAccount.Email);
+            var accessToken = _jwtService.GenerateToken(user.Id, user.PersonId);
             var refreshToken = await _refreshTokenService.CreateAsync(user.Id, cancellationToken);
 
             var userDto = await _userService.GetByIdDtoAsync(user.Id, cancellationToken);
@@ -108,7 +108,7 @@ namespace CareGuide.Core.Services
                 throw new UnauthorizedAccessException("Invalid email.");
 
             var newRefresh = await _refreshTokenService.RotateAsync(user.Id, refreshTokenDto.RefreshToken, cancellationToken);
-            string newAccessToken = _jwtService.GenerateToken(user.Id, user.PersonId, user.Email);
+            string newAccessToken = _jwtService.GenerateToken(user.Id, user.PersonId);
 
             var userDto = await _userService.GetByIdDtoAsync(user.Id, cancellationToken);
             var personDto = await _personService.GetAsync(user.PersonId!.Value, cancellationToken);

--- a/src/CareGuide.Infra/CareGuide.Infra.csproj
+++ b/src/CareGuide.Infra/CareGuide.Infra.csproj
@@ -7,17 +7,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.5" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.5">
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.5">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.4" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.4" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
   </ItemGroup>
 

--- a/src/CareGuide.Security/Contexts/UserSessionContext.cs
+++ b/src/CareGuide.Security/Contexts/UserSessionContext.cs
@@ -1,4 +1,4 @@
-﻿using CareGuide.Security.Interfaces;
+using CareGuide.Security.Interfaces;
 using Microsoft.AspNetCore.Http;
 using System.Security.Claims;
 
@@ -8,38 +8,22 @@ namespace CareGuide.Security.Contexts
     {
         public Guid UserId { get; private set; }
         public Guid PersonId { get; private set; }
-        public string Email { get; private set; } = string.Empty;
 
-        public UserSessionContext(IHttpContextAccessor httpContextAccessor, IJwtService jwtService)
+        public UserSessionContext(IHttpContextAccessor httpContextAccessor)
         {
-            var httpContext = httpContextAccessor.HttpContext;
+            var user = httpContextAccessor.HttpContext?.User;
 
-            if (httpContext == null)
+            if (user?.Identity?.IsAuthenticated != true)
                 return;
 
-            if (!httpContext.Request.Headers.TryGetValue("Authorization", out var headerAuth))
-                return;
-
-            var tokenString = headerAuth.ToString().Replace("Bearer ", "", StringComparison.OrdinalIgnoreCase);
-            var token = jwtService.ValidateToken(tokenString);
-
-            if (token == null)
-                return;
-
-            UserId = GetGuidClaim(token.Claims, "sub");
-            PersonId = GetGuidClaim(token.Claims, "personId");
-            Email = GetStringClaim(token.Claims, "email");
+            UserId = GetGuidClaim(user.Claims, "sub");
+            PersonId = GetGuidClaim(user.Claims, "personId");
         }
 
         private static Guid GetGuidClaim(IEnumerable<Claim> claims, string type)
         {
             var value = claims.FirstOrDefault(c => c.Type == type)?.Value;
             return Guid.TryParse(value, out var guid) ? guid : Guid.Empty;
-        }
-
-        private static string GetStringClaim(IEnumerable<Claim> claims, string type)
-        {
-            return claims.FirstOrDefault(c => c.Type == type)?.Value ?? string.Empty;
         }
     }
 }

--- a/src/CareGuide.Security/DTOs/SecuritySettingsDto.cs
+++ b/src/CareGuide.Security/DTOs/SecuritySettingsDto.cs
@@ -1,9 +1,9 @@
-﻿namespace CareGuide.Security.DTOs
+namespace CareGuide.Security.DTOs
 {
     public class SecuritySettingsDto
     {
-        public string SecretKey { get; set; }
-        public string Issuer { get; set; }
-        public string Audience { get; set; }
+        public required string SecretKey { get; set; }
+        public required string Issuer { get; set; }
+        public string? Audience { get; set; }
     }
 }

--- a/src/CareGuide.Security/DependencyInjection.cs
+++ b/src/CareGuide.Security/DependencyInjection.cs
@@ -12,6 +12,8 @@ namespace CareGuide.Security
 {
     public static class DependencyInjection
     {
+        private const int MinSecretKeyBytes = 64; // HMACSHA512 requires at least 512 bits
+
         public static IServiceCollection AddSecurity(this IServiceCollection services, IConfiguration configuration)
         {
             services.AddScoped<IJwtService, JwtService>();
@@ -20,6 +22,8 @@ namespace CareGuide.Security
             services.AddOptions<SecuritySettingsDto>()
                 .Bind(configuration.GetSection("SecuritySettings"))
                 .Validate(settings => !string.IsNullOrWhiteSpace(settings.SecretKey), "SecuritySettings:SecretKey is required.")
+                .Validate(settings => Encoding.UTF8.GetByteCount(settings.SecretKey ?? string.Empty) >= MinSecretKeyBytes,
+                    $"SecuritySettings:SecretKey must be at least {MinSecretKeyBytes} bytes (256 bits).")
                 .Validate(settings => !string.IsNullOrWhiteSpace(settings.Issuer), "SecuritySettings:Issuer is required.")
                 .ValidateOnStart();
 
@@ -29,6 +33,9 @@ namespace CareGuide.Security
 
             if (string.IsNullOrWhiteSpace(secretKey))
                 throw new InvalidOperationException("SecuritySettings:SecretKey is not configured.");
+
+            if (Encoding.UTF8.GetByteCount(secretKey) < MinSecretKeyBytes)
+                throw new InvalidOperationException($"SecuritySettings:SecretKey must be at least {MinSecretKeyBytes} bytes (256 bits).");
 
             if (string.IsNullOrWhiteSpace(issuer))
                 throw new InvalidOperationException("SecuritySettings:Issuer is not configured.");
@@ -40,6 +47,8 @@ namespace CareGuide.Security
             })
             .AddJwtBearer(options =>
             {
+                options.MapInboundClaims = false;
+
                 options.TokenValidationParameters = new TokenValidationParameters
                 {
                     ValidateIssuerSigningKey = true,
@@ -48,7 +57,24 @@ namespace CareGuide.Security
                     ValidIssuer = issuer,
                     ValidateAudience = !string.IsNullOrWhiteSpace(audience),
                     ValidAudience = audience,
+                    ValidateLifetime = true,
+                    ClockSkew = TimeSpan.Zero,
                     NameClaimType = "sub"
+                };
+
+                // Support both HttpOnly cookie (browser) and Authorization header (API clients)
+                options.Events = new JwtBearerEvents
+                {
+                    OnMessageReceived = context =>
+                    {
+                        if (!context.HttpContext.Request.Headers.ContainsKey("Authorization"))
+                        {
+                            var token = context.HttpContext.Request.Cookies["sessionToken"];
+                            if (!string.IsNullOrWhiteSpace(token))
+                                context.Token = token;
+                        }
+                        return Task.CompletedTask;
+                    }
                 };
             });
 

--- a/src/CareGuide.Security/Helpers/PasswordManagerHelper.cs
+++ b/src/CareGuide.Security/Helpers/PasswordManagerHelper.cs
@@ -16,7 +16,8 @@ namespace CareGuide.Security.Helpers
         public static bool ValidatePassword(string password, string hash)
         {
             var result = hasher.VerifyHashedPassword(HashScope, hash, password);
-            return result == PasswordVerificationResult.Success;
+            return result is PasswordVerificationResult.Success
+                         or PasswordVerificationResult.SuccessRehashNeeded;
         }
 
         public static (bool IsSecure, string Feedback) CheckPassword(string password)

--- a/src/CareGuide.Security/Interfaces/IJwtService.cs
+++ b/src/CareGuide.Security/Interfaces/IJwtService.cs
@@ -4,7 +4,7 @@ namespace CareGuide.Security.Interfaces
 {
     public interface IJwtService
     {
-        string GenerateToken(Guid userId, Guid? personId, string email);
+        string GenerateToken(Guid userId, Guid? personId);
         JwtSecurityToken? ValidateToken(string token);
         string GenerateRefreshToken();
     }

--- a/src/CareGuide.Security/Interfaces/IUserSessionContext.cs
+++ b/src/CareGuide.Security/Interfaces/IUserSessionContext.cs
@@ -4,6 +4,5 @@
     {
         Guid UserId { get; }
         Guid PersonId { get; }
-        string Email { get; }
     }
 }

--- a/src/CareGuide.Security/Services/JwtService.cs
+++ b/src/CareGuide.Security/Services/JwtService.cs
@@ -13,7 +13,7 @@ namespace CareGuide.Security.Services
     {
         private readonly string _secretKey;
         private readonly string _issuer;
-        private readonly string _audience;
+        private readonly string? _audience;
 
         public JwtService(IOptions<SecuritySettingsDto> settings)
         {
@@ -24,10 +24,10 @@ namespace CareGuide.Security.Services
             _audience = securitySettings.Audience;
         }
 
-        public string GenerateToken(Guid userId, Guid? personId, string email)
+        public string GenerateToken(Guid userId, Guid? personId)
         {
             SymmetricSecurityKey key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(_secretKey));
-            SigningCredentials creds = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
+            SigningCredentials creds = new SigningCredentials(key, SecurityAlgorithms.HmacSha512);
 
             JwtSecurityToken token = new JwtSecurityToken(
                 issuer: _issuer,
@@ -36,7 +36,6 @@ namespace CareGuide.Security.Services
                 {
                     new Claim(JwtRegisteredClaimNames.Sub, userId.ToString()),
                     new Claim("personId", personId?.ToString() ?? string.Empty),
-                    new Claim(JwtRegisteredClaimNames.Email, email),
                     new Claim(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString())
                 },
                 expires: DateTime.UtcNow.AddMinutes(15),
@@ -65,7 +64,7 @@ namespace CareGuide.Security.Services
                     ClockSkew = TimeSpan.Zero,
                 }, out SecurityToken validatedToken);
 
-                return new JwtSecurityTokenHandler().ReadJwtToken(token);
+                return (JwtSecurityToken)validatedToken;
             }
             catch
             {

--- a/src/CareGuide.Tests/Services/AccountServiceTests.cs
+++ b/src/CareGuide.Tests/Services/AccountServiceTests.cs
@@ -53,7 +53,7 @@ public class AccountServiceTests
         _mapper.Map<CreateUserDto>(createDto).Returns(new CreateUserDto(Guid.NewGuid(), DefaultPersonDto.Id, "new@test.com", "Str0ng@Pass!"));
         _personService.CreateAsync(Arg.Any<CreatePersonDto>(), Arg.Any<CancellationToken>()).Returns(DefaultPersonDto);
         _userService.CreateAsync(DefaultPersonDto, Arg.Any<CreateUserDto>(), Arg.Any<CancellationToken>()).Returns(DefaultUserDto);
-        _jwtService.GenerateToken(DefaultUserDto.Id, DefaultPersonDto.Id, DefaultUserDto.Email).Returns("access-token");
+        _jwtService.GenerateToken(DefaultUserDto.Id, DefaultPersonDto.Id).Returns("access-token");
         _refreshTokenService.CreateAsync(DefaultUserDto.Id, Arg.Any<CancellationToken>()).Returns(refreshToken);
 
         var result = await _sut.CreateAccountAsync(createDto, CancellationToken.None);
@@ -130,7 +130,7 @@ public class AccountServiceTests
         var refreshToken = new RefreshToken { UserId = user.Id, Token = "refresh-token" };
 
         _userRepository.GetByEmailAsync(loginDto.Email, Arg.Any<CancellationToken>()).Returns(user);
-        _jwtService.GenerateToken(user.Id, user.PersonId, loginDto.Email).Returns("access-token");
+        _jwtService.GenerateToken(user.Id, user.PersonId).Returns("access-token");
         _refreshTokenService.CreateAsync(user.Id, Arg.Any<CancellationToken>()).Returns(refreshToken);
         _userService.GetByIdDtoAsync(user.Id, Arg.Any<CancellationToken>()).Returns(DefaultUserDto);
         _personService.GetAsync(user.PersonId!.Value, Arg.Any<CancellationToken>()).Returns(DefaultPersonDto);


### PR DESCRIPTION
Consolida melhorias de segurança em múltiplas camadas da aplicação:

Auth/JWT: adiciona ValidateLifetime e ClockSkew=Zero no AddJwtBearer, migra para HMACSHA512, valida tamanho mínimo de 64 bytes na SecretKey, remove email do payload JWT (LGPD), adiciona suporte a sessionToken via cookie HttpOnly no OnMessageReceived, simplifica UserSessionContext para ler claims do pipeline do framework (sem revalidação manual), e trata SuccessRehashNeeded no validador de senha.

Rate limiting: substitui fixed window global por sliding window (geral, 60 req/min) e fixed window restritivo para endpoints de autenticação (5 req/min), com resolução de IP via X-Forwarded-For, header Retry-After na rejeição e ForwardedHeaders middleware.

Dependências: corrige 2 CVEs de alta severidade no pacote transitivo System.Security.Cryptography.Xml via Directory.Build.props (força versão 10.0.8) e alinha EF Core para 10.0.4 eliminando conflito de versão com Npgsql 10.0.1.

Build: 0 warnings, 0 errors. Testes: 307/307 passando.